### PR TITLE
Fixed duplicate links on pages without an URL

### DIFF
--- a/sitemap.php
+++ b/sitemap.php
@@ -310,6 +310,13 @@ class Sitemap extends Module
                     $idObj = 0;
                 }
             }
+            foreach($linkSitemap as $key => $link) {
+                if($key!=0) {
+                    if ($link['link']==$linkSitemap[0]['link']) {
+                        unset($linkSitemap[$key]);
+                    }
+                }
+            }
             $this->_recursiveSitemapCreator($linkSitemap, $lang['iso_code'], $index);
             $page = '';
             $index = 0;


### PR DESCRIPTION
Without this fix, the generated sitemap would have a lot of duplicates on the home page from front controllers without a set URL.
Ideally this could probably be changed to some sort of verification in _addLinkToSitemap to make sure it is simply never added to the array but I would not know what to check it against.