### PR TITLE
Exclude PS_HOME_CATEGORY from sitemap creation.

### DIFF
--- a/sitemap.php
+++ b/sitemap.php
@@ -676,10 +676,12 @@ class Sitemap extends Module
             ShopUrl::resetMainDomainCache();
         }
 
+        $rootCategoryId = (int) Configuration::get('PS_ROOT_CATEGORY');
+        $homeCategoryId = (int) Configuration::get('PS_HOME_CATEGORY');
         $categoryIds = Db::getInstance()->ExecuteS(
             'SELECT c.id_category FROM `'._DB_PREFIX_.'category` c
 				INNER JOIN `'._DB_PREFIX_.'category_shop` cs ON c.`id_category` = cs.`id_category`
-				WHERE c.`id_category` >= '.intval($idCategory).' AND c.`active` = 1 AND c.`id_category` != 1 AND c.id_parent > 0 AND c.`id_category` > 0 AND cs.`id_shop` = '.(int) $this->context->shop->id.' ORDER BY c.`id_category` ASC'
+				WHERE c.`id_category` >= '.(int) $idCategory.' AND c.`active` = 1 AND c.`id_category` != '.$rootCategoryId.' AND c.`id_category` != '.$homeCategoryId.' AND c.id_parent > 0 AND c.`id_category` > 0 AND cs.`id_shop` = '.(int) $this->context->shop->id.' ORDER BY c.`id_category` ASC'
         );
 
         foreach ($categoryIds as $categoryId) {


### PR DESCRIPTION
In accordance with [this](https://github.com/thirtybees/thirtybees/blob/11bfce5ab61fe1aea229972772527b6d27190550/controllers/front/CategoryController.php#L96) and other places, PS_HOME_CATEGORY is inaccessible at the front office as well as PS_ROOT_CATEGORY. Therefore, it should be excluded from the Sitemap generation as well. Otherwise it will create unnecessary 404 for googlebot.