### PR TITLE
Fixed generation of non existent - root categories

### DIFF
--- a/sitemap.php
+++ b/sitemap.php
@@ -681,7 +681,7 @@ class Sitemap extends Module
         $categoryIds = Db::getInstance()->ExecuteS(
             'SELECT c.id_category FROM `'._DB_PREFIX_.'category` c
 				INNER JOIN `'._DB_PREFIX_.'category_shop` cs ON c.`id_category` = cs.`id_category`
-				WHERE c.`id_category` >= '.(int) $idCategory.' AND c.`active` = 1 AND c.`id_category` != '.$rootCategoryId.' AND c.`id_category` != '.$homeCategoryId.' AND c.id_parent > 0 AND c.`id_category` > 0 AND cs.`id_shop` = '.(int) $this->context->shop->id.' ORDER BY c.`id_category` ASC'
+				WHERE c.`id_category` >= '.(int) $idCategory.' AND c.`active` = 1 AND c.`id_category` != '.$rootCategoryId.' AND c.`id_category` != '.$homeCategoryId.' AND c.id_parent > 0 AND c.`id_category` > 0 AND cs.`id_shop` = '.(int) $this->context->shop->id.' AND c.`is_root_category` != 1 ORDER BY c.`id_category` ASC'
         );
 
         foreach ($categoryIds as $categoryId) {


### PR DESCRIPTION
Module used to generate /home or /root category entries in sitemap. Now are root categories excluded from sitemap.